### PR TITLE
fix: broken golangci-lint-action configuration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,7 +62,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v1
         with:
-          version: v1.27
+          version: v1.28
           github-token: ${{ secrets.GITHUB_TOKEN }}
           args: --timeout=2m
           only-new-issues: false


### PR DESCRIPTION
Related with https://github.com/golangci/golangci-lint-action/issues/37